### PR TITLE
WIP: sync file modes b/w sandbox: limitation of oc cp

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ m_dir = MappedDir(
 o = Sandcastle(
     image_reference=container_image,
     k8s_namespace_name=namespace,      # can be a different namespace
-    mapped_dirs=[m_dir],
+    mapped_dir=m_dir,
     working_dir=sandbox_mountpoint,
 )
 o.run()

--- a/sandcastle/api.py
+++ b/sandcastle/api.py
@@ -45,6 +45,8 @@ We came up with these solutions:
 import json
 import logging
 import os
+import shlex
+import tempfile
 import time
 from pathlib import Path
 from typing import Dict, List, Optional, Union
@@ -59,6 +61,7 @@ from sandcastle.exceptions import (
     SandcastleCommandFailed,
     SandcastleExecutionError,
     SandcastleTimeoutReached,
+    SandcastleException,
 )
 from sandcastle.kube import PVC
 from sandcastle.utils import (
@@ -66,6 +69,7 @@ from sandcastle.utils import (
     clean_string,
     run_command,
     purge_dir_content,
+    Chmodo,
 )
 
 logger = logging.getLogger(__name__)
@@ -121,7 +125,7 @@ class Sandcastle(object):
         working_dir: Optional[str] = None,
         service_account_name: Optional[str] = None,
         volume_mounts: Optional[List[VolumeSpec]] = None,
-        mapped_dirs: Optional[List[MappedDir]] = None,
+        mapped_dir: Optional[MappedDir] = None,
     ):
         """
         :param image_reference: the pod will use this image
@@ -131,8 +135,10 @@ class Sandcastle(object):
         :param working_dir: path within the pod where we run commands by default
         :param service_account_name: run the pod using this service account
         :param volume_mounts: set these volume mounts in the sandbox
-        :param mapped_dirs, a list of mappings between a local dir which should be copied
+        :param mapped_dir, a mapping between a local dir which should be copied
                to the sandbox, and then copied back once all the work is done
+               when this is set, working_dir args is being ignored and sandcastle invokes
+               all exec commands in the working dir of the mapped dir
         """
         self.image_reference: str = image_reference
         self.service_account_name: Optional[str] = service_account_name
@@ -145,9 +151,12 @@ class Sandcastle(object):
         self.pod_name = pod_name or f"{self.cleaned_name}-{get_timestamp_now()}"
 
         self.working_dir = working_dir
+        if working_dir and mapped_dir:
+            logger.warning("Ignoring warning_dir becase mapped_dir is set.")
+            self.working_dir = None
         self.api: client.CoreV1Api = self.get_api_client()
         self.volume_mounts: List[VolumeSpec] = volume_mounts or []
-        self.mapped_dirs: List[MappedDir] = mapped_dirs or []
+        self.mapped_dir: MappedDir = mapped_dir
         self.pvc: Optional[PVC] = None
 
     # TODO: refactor into a pod class
@@ -178,19 +187,18 @@ class Sandcastle(object):
         if self.service_account_name:
             spec["serviceAccountName"] = self.service_account_name
 
-        for md in self.mapped_dirs:
-            if md.with_interim_pvc:
-                self.pvc = PVC(path=md.path)
-                self.api.create_namespaced_persistent_volume_claim(
-                    namespace=self.k8s_namespace_name, body=self.pvc.to_dict()
+        if self.mapped_dir and self.mapped_dir.with_interim_pvc:
+            self.pvc = PVC(path=self.mapped_dir.path)
+            self.api.create_namespaced_persistent_volume_claim(
+                namespace=self.k8s_namespace_name, body=self.pvc.to_dict()
+            )
+            self.volume_mounts.append(
+                VolumeSpec(
+                    path=self.pvc.path,
+                    volume_name=self.pvc.volume_name,
+                    pvc=self.pvc.claim_name,
                 )
-                self.volume_mounts.append(
-                    VolumeSpec(
-                        path=self.pvc.path,
-                        volume_name=self.pvc.volume_name,
-                        pvc=self.pvc.claim_name,
-                    )
-                )
+            )
 
         if self.volume_mounts:
             volume_mounts: List[Dict] = []
@@ -325,8 +333,8 @@ class Sandcastle(object):
         """
         Deploy a pod and babysit it. If it exists already, remove it.
         """
-        if self.mapped_dirs and command:
-            raise RuntimeError(
+        if self.mapped_dir and command:
+            raise SandcastleException(
                 "Since you set your own command, we cannot sync the local dir"
                 " inside because there is a race condition between the pod start"
                 " and the copy process. Please use exec instead."
@@ -430,6 +438,45 @@ class Sandcastle(object):
             _preload_content=preload_content,  # <<< we need a client object
         )
 
+    def _prepare_mdir_exec(
+        self, local_dir: Path, command: List[str], target_dir: Optional[Path] = None
+    ):
+        """
+        wrap a command to exec in the sandbox in a script
+
+        :param local_dir: local dir to sync
+        :param command: command to wrap
+        :param target_dir: a dir in the sandbox where the script is supposed to be copied
+        :return: (path to the sync'd dir within sandbox, path to the script within sandbox)
+        """
+        cmd_str = ""
+        for c in command:
+            cmd_str += f"{shlex.quote(c)} "
+
+        root_target_dir = target_dir or self._do_exec(["mktemp"]).strip()
+        # this is where the content of mapped_dir will be
+        unique_dir = os.path.join(root_target_dir, self.pod_name)
+        script_name = "script.sh"
+        target_script_path = os.path.join(root_target_dir, script_name)
+
+        chmodo = Chmodo(path=local_dir)
+        # git checkout - oc cp does not preserve the file mode and makes the repo dirty
+        script_template = (
+            "#!/bin/bash\n"
+            f"cd {unique_dir}\n"
+            f"{chmodo.get_shell_script()}"
+            f"exec {cmd_str}\n"
+        )
+        fd, name = tempfile.mkstemp()
+        try:
+            os.write(fd, script_template.encode("utf-8"))
+            self._do_exec(["mkdir", "-p", unique_dir]).strip()
+            self._copy_path_to_pod(Path(name), target_script_path)
+        finally:
+            os.close(fd)
+            os.unlink(name)
+        return unique_dir, target_script_path
+
     def exec(self, command: List[str]) -> str:
         """
         exec a command in a running pod
@@ -443,13 +490,21 @@ class Sandcastle(object):
             raise SandcastleTimeoutReached(
                 "You have reached a timeout: the pod is no longer running."
             )
-        for m_dir in self.mapped_dirs:
-            self._copy_path_to_pod(m_dir)
+        logger.info("command = %s", command)
+        unique_dir = None
+        if self.mapped_dir:
+            unique_dir, target_script_path = self._prepare_mdir_exec(
+                self.mapped_dir.local_dir, command, target_dir=self.mapped_dir.path
+            )
+            command = ["bash", target_script_path]
+            self._copy_path_to_pod(self.mapped_dir.local_dir, unique_dir)
         # https://github.com/kubernetes-client/python/blob/master/examples/exec.py
         # https://github.com/kubernetes-client/python/issues/812#issuecomment-499423823
+        # FIXME: refactor this junk into a dedicated function, ideally to _do_exec
         ws_client: WSClient = self._do_exec(command, preload_content=False)
         ws_client.run_forever(timeout=60)
         errors = ws_client.read_channel(ERROR_CHANNEL)
+        logger.debug("%s", errors)
         # read_all would consume ERR_CHANNEL, so read_all needs to be last
         response = ws_client.read_all()
         if errors:
@@ -458,12 +513,11 @@ class Sandcastle(object):
             status = j.get("status", None)
             if status == "Success":
                 logger.info("exec command succeeded, yay!")
-                for m_dir in self.mapped_dirs:
-                    self._copy_path_from_pod(m_dir)
+                self._copy_mdir_from_pod(unique_dir)
             elif status == "Failure":
                 logger.info("exec command failed")
-                for m_dir in self.mapped_dirs:
-                    self._copy_path_from_pod(m_dir)
+                self._copy_mdir_from_pod(unique_dir)
+
                 # ('{"metadata":{},"status":"Failure","message":"command terminated with '
                 #  'non-zero exit code: Error executing in Docker Container: '
                 #  '1","reason":"NonZeroExitCode","details":{"causes":[{"reason":"ExitCode","message":"1"}]}}')
@@ -485,36 +539,63 @@ class Sandcastle(object):
         logger.debug("exec response = %r" % response)
         return response
 
-    def _copy_path_to_pod(self, m_dir: MappedDir):
-        """ copy local path inside the pod """
-        # Copy /tmp/foo local file to /tmp/bar
-        # in a remote pod in namespace <some-namespace>:
-        #   oc cp /tmp/foo <some-namespace>/<some-pod>:/tmp/bar
-        target = f"{self.k8s_namespace_name}/{self.pod_name}:{m_dir.path}"
-        logger.info(f"copy {m_dir.local_dir} -> {target}")
-        # if you're interested: the way openshift does this is that creates a tarball locally
-        # and streams it via exec into the container to a pod process
-        for item in m_dir.local_dir.iterdir():
-            # tar: lost+found: Cannot utime: Operation not permitted
-            if item.name == "lost+found":
-                continue
-            # we are doing this insanity because of two things:
-            #   1. tar creates a root dir in the tarball, so we would need to cd into it
-            #   2. this way we can set working_dir to m_dir.path in the pod
-            logger.debug(f"copy item {item} -> {target}")
-            run_command(["oc", "cp", item, target])
+    def _copy_path_to_pod(self, local_path: Path, pod_path: str):
+        """
+        copy local_path (dir or file) inside pod
 
-    def _copy_path_from_pod(self, m_dir: MappedDir):
-        """ copy remote path content locally """
+        :param local_path: path to a local file or a dir
+        :param pod_path: path within the pod
+        """
+        # we are doing this insanity (the loop) because of two things:
+        #   1. tar creates a root dir in the tarball, so we would need to cd into it
+        #   2. this way we can set working_dir to m_dir.path in the pod
+        if local_path.is_file():
+            items = [local_path]
+        else:
+            items = list(local_path.iterdir())
+        for item in items:
+            if item.name == "lost+found":
+                # tar: lost+found: Cannot utime: Operation not permitted
+                continue
+            logger.debug("copy %s -> %s", item, pod_path)
+            # Copy /tmp/foo local file to /tmp/bar
+            # in a remote pod in namespace <some-namespace>:
+            #   oc cp /tmp/foo <some-namespace>/<some-pod>:/tmp/bar
+            target = f"{self.k8s_namespace_name}/{self.pod_name}:{pod_path}"
+            # if you're interested: the way openshift does this is that creates a tarball locally
+            # and streams it via exec into the container to a pod process
+            run_command(["oc", "cp", str(item), target])
+
+    def _copy_path_from_pod(self, local_dir: Path, pod_dir: str):
+        """
+        copy content of a dir from pod locally
+
+        :param local_dir: path to the local dir
+        :param pod_dir: path within the pod
+        """
         # Copy /tmp/foo from a remote pod to /tmp/bar locally
         #   oc cp <some-namespace>/<some-pod>:/tmp/foo /tmp/bar
-        target = f"{self.k8s_namespace_name}/{self.pod_name}:{m_dir.path}"
+        target = f"{self.k8s_namespace_name}/{self.pod_name}:{pod_dir}"
 
         # temp_dir = Path(tempfile.mkdtemp())
         # logger.info(f"copy {target} -> {temp_dir}")
         # run_command(["oc", "cp", target, temp_dir])
 
-        purge_dir_content(m_dir.local_dir)
+        purge_dir_content(Path(local_dir))
 
-        logger.info(f"copy {target} -> {m_dir.local_dir}")
-        run_command(["oc", "cp", target, m_dir.local_dir])
+        logger.info(f"copy {target} -> {local_dir}")
+        run_command(["oc", "cp", target, local_dir])
+
+    def _copy_mdir_from_pod(self, unique_dir: str):
+        """ process mapped_dir after we are done execing """
+        if self.mapped_dir:
+            logger.debug("mapped_dir is set, let's sync the dir back and fix modes")
+            self._copy_path_from_pod(
+                local_dir=self.mapped_dir.local_dir, pod_dir=unique_dir
+            )
+            # fix mode now
+            chmodo = Chmodo(path=self.mapped_dir.local_dir)
+            script = f"cd {unique_dir} && find . -exec stat -c '%a %n' {{}} \\;"
+            c = ["bash", "-c", script]
+            modes_paths = self._do_exec(c)
+            chmodo.apply_chmods(modes_paths)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from pathlib import Path
+
+import pytest
+
+from sandcastle.utils import Chmodo
+
+
+@pytest.fixture()
+def good_testing_tree(tmpdir) -> Path:
+    p = Path(tmpdir)
+    test_dir = p.joinpath("tree")
+    test_dir.mkdir()
+    d = test_dir.joinpath("d")
+    d.mkdir()
+    d.joinpath("f").write_text("a")
+    d.joinpath("f").chmod(0o777)
+    e = test_dir.joinpath("e")
+    e.mkdir()
+    e.joinpath("g").write_text("b")
+    e.joinpath("g").chmod(0o640)
+    test_dir.joinpath("h").mkdir()
+    test_dir.joinpath("h").chmod(0o777)
+    return test_dir
+
+
+def test_chmodo_list_files(good_testing_tree):
+    tree = good_testing_tree
+    c = Chmodo(path=tree)
+    result = c.get_files_and_mode()
+    assert (tree.joinpath("d"), "0o40775") in result
+    assert (tree.joinpath("d").joinpath("f"), "0o100777") in result
+    assert (tree.joinpath("e"), "0o40775") in result
+    assert (tree.joinpath("e").joinpath("g"), "0o100640") in result
+    assert (tree.joinpath("h"), "0o40777") in result
+
+
+def test_chmodo_the_script(good_testing_tree):
+    tree = good_testing_tree
+    c = Chmodo(path=tree)
+    result = c.get_shell_script()
+    assert "chmod 775 d" in result
+    assert "chmod 777 d/f" in result
+    assert "chmod 775 e" in result
+    assert "chmod 640 e/g" in result
+    assert "chmod 777 h" in result


### PR DESCRIPTION
Fixes #https://github.com/packit-service/packit-service/issues/29

TODO:

* [x] make this actually work
    ```
    [2019-07-01 10:59:31,312: DEBUG/ForkPoolWorker-1] exec response = 'Wrote: ./packit-0.4.2.dev64+ga679bc5-1.fc30.src.rpm\n'
    [2019-07-01 10:59:31,312: DEBUG/ForkPoolWorker-1] Wrote: ./packit-0.4.2.dev64+ga679bc5-1.fc30.src.rpm
    [2019-07-01 10:59:31,325: DEBUG/ForkPoolWorker-1] content of the volume: [PosixPath('/sandcastle/.git'), PosixPath('/sandcastle/docs'), PosixPath('/sandcastle/fedora-tests'$
    , PosixPath('/sandcastle/files'), PosixPath('/sandcastle/packit'), PosixPath('/sandcastle/tests'), PosixPath('/sandcastle/.eggs'), PosixPath('/sandcastle/packitos.egg-info'$
    , PosixPath('/sandcastle/.git_archival.txt'), PosixPath('/sandcastle/.gitattributes'), PosixPath('/sandcastle/.gitignore'), PosixPath('/sandcastle/.pre-commit-config.yaml')$
     PosixPath('/sandcastle/CONTRIBUTING.md'), PosixPath('/sandcastle/Dockerfile'), PosixPath('/sandcastle/Jenkinsfile'), PosixPath('/sandcastle/LICENSE'), PosixPath('/sandcast$
    e/Makefile'), PosixPath('/sandcastle/README.md'), PosixPath('/sandcastle/Vagrantfile'), PosixPath('/sandcastle/ansible.cfg'), PosixPath('/sandcastle/recipe-tests.yaml'), Po$
    ixPath('/sandcastle/release-conf.yaml'), PosixPath('/sandcastle/setup.py'), PosixPath('/sandcastle/.packit.yaml'), PosixPath('/sandcastle/CHANGELOG.md'), PosixPath('/sandca$
    tle/packit.spec'), PosixPath('/sandcastle/setup.cfg'), PosixPath('/sandcastle/packitos-0.4.2.dev64+ga679bc5.tar.gz'), PosixPath('/sandcastle/packit-0.4.2.dev64+ga679bc5-1.f$
    30.src.rpm')]
    [2019-07-01 10:59:31,338: ERROR/ForkPoolWorker-1] Task task.steve_jobs.process_message[a4cbd763-0079-4a73-b866-b5d47f317e99] raised unexpected: AssertionError()
    Traceback (most recent call last):
      File "/usr/local/lib/python3.7/site-packages/celery/app/trace.py", line 385, in trace_task
        R = retval = fun(*args, **kwargs)
      File "/usr/local/lib/python3.7/site-packages/celery/app/trace.py", line 648, in __protected_call__
        return self.run(*args, **kwargs)
      File "/usr/local/lib/python3.7/site-packages/packit_service/worker/tasks.py", line 31, in process_message
        return SteveJobs().process_message(event=event, topic=topic)
      File "/usr/local/lib/python3.7/site-packages/packit_service/worker/jobs.py", line 372, in process_message
        jobs_results = self.process_jobs(trigger, package_config, event, project)
      File "/usr/local/lib/python3.7/site-packages/packit_service/worker/jobs.py", line 330, in process_jobs
        handlers_results[job.job.value] = handler.run()
      File "/usr/local/lib/python3.7/site-packages/packit_service/worker/jobs.py", line 751, in run
        return self.handle_pull_request()
      File "/usr/local/lib/python3.7/site-packages/packit_service/worker/jobs.py", line 699, in handle_pull_request
        owner=owner, project=project, chroots=self.job.metadata.get("targets")
      File "/usr/local/lib/python3.7/site-packages/packit/api.py", line 542, in run_copr_build
        assert srpm_path.exists()
    AssertionError
    ```
 * @jscotka suggested that we should tar the dir and use only a single oc cp call, which is great suggestion