### PR TITLE
don't try to chmod .

### DIFF
--- a/sandcastle/api.py
+++ b/sandcastle/api.py
@@ -593,15 +593,11 @@ class Sandcastle(object):
         remote_tmp_dir = Path(self._do_exec(["mktemp", "-d"]).strip())
         try:
             remote_tar_path = remote_tmp_dir.joinpath("t.tar.gz")
-            pack_cmd = [
-                "tar",
-                "--preserve-permissions",
-                "-czf",
-                str(remote_tar_path),
-                "-C",
-                str(pod_dir),
-                ".",
-            ]
+            grc = (
+                rf"cd {pod_dir} && ls -d -1 .* * | egrep -v '^\.$' | egrep -v '^\.\.$'"
+            )
+            tar_cmd = f"tar -czf {remote_tar_path} -C {pod_dir} $({grc})"
+            pack_cmd = ["bash", "-c", tar_cmd]
             self._do_exec(pack_cmd)
 
             # Copy /tmp/foo from a remote pod to /tmp/bar locally

--- a/sandcastle/api.py
+++ b/sandcastle/api.py
@@ -493,8 +493,7 @@ class Sandcastle(object):
         try:
             # https://github.com/packit-service/sandcastle/issues/23
             # even with a >0 number or ==0, select tends to block
-            # setting it 0 could make things better
-            ws_client.run_forever(timeout=0)
+            ws_client.run_forever(timeout=60.0)
             errors = ws_client.read_channel(ERROR_CHANNEL)
             logger.debug("%s", errors)
             # read_all would consume ERR_CHANNEL, so read_all needs to be last

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,10 +87,7 @@ def run_test_within_pod(
     cont_cmd = [
         "bash",
         "-c",
-        "ls -lha "
-        "&& id "
-        "&& pytest-3 --collect-only"
-        f"&& pytest-3 -vv -l -p no:cacheprovider {test_path}",
+        "ls -lha " f"&& pytest-3 -vv -l -p no:cacheprovider {test_path}",
     ]
 
     container: Dict[str, Any] = {

--- a/tests/e2e/test_ironman.py
+++ b/tests/e2e/test_ironman.py
@@ -27,7 +27,7 @@ import pytest
 
 from sandcastle import Sandcastle, VolumeSpec, SandcastleTimeoutReached, MappedDir
 from sandcastle.exceptions import SandcastleCommandFailed
-from sandcastle.utils import run_command, get_timestamp_now
+from sandcastle.utils import run_command, get_timestamp_now, purge_dir_content
 from tests.conftest import (
     SANDBOX_IMAGE,
     NAMESPACE,
@@ -182,11 +182,15 @@ def test_file_got_changed(tmpdir):
     "git_url,branch",
     (
         ("https://github.com/packit-service/hello-world.git", "master"),
-        ("https://github.com/TomasTomecek/packit.git", "sandz"),
+        ("https://github.com/packit-service/packit.git", "master"),
     ),
 )
 def test_md_e2e(tmpdir, git_url, branch):
-    t = Path(tmpdir)
+    # running in k8s
+    if "KUBERNETES_SERVICE_HOST" in os.environ:
+        t = Path(SANDCASTLE_MOUNTPOINT).joinpath(f"clone-{get_timestamp_now()}")
+    else:
+        t = Path(tmpdir)
     m_dir = MappedDir(str(t), SANDCASTLE_MOUNTPOINT, with_interim_pvc=True)
 
     run_command(["git", "clone", "-b", branch, git_url, t])
@@ -196,8 +200,9 @@ def test_md_e2e(tmpdir, git_url, branch):
     )
     o.run()
     try:
-        o.exec(command=["packit", "srpm"])
+        o.exec(command=["packit", "--debug", "srpm"])
         assert list(t.glob("*.src.rpm"))
+        o.exec(command=["packit", "--help"])
     finally:
         o.delete_pod()
 
@@ -271,12 +276,22 @@ def test_lost_found_is_ignored(tmpdir):
 
 
 def test_changing_mode(tmpdir):
-    t = Path(tmpdir)
+    # running in k8s
+    if "KUBERNETES_SERVICE_HOST" in os.environ:
+        t = Path(SANDCASTLE_MOUNTPOINT)
+    else:
+        t = Path(tmpdir)
     m_dir = MappedDir(str(t), SANDCASTLE_MOUNTPOINT)
 
     fi = t.joinpath("file")
     fi.write_text("asd")
     fi.chmod(mode=0o777)
+    fi2 = t.joinpath("file2")
+    fi2.write_text("qwe")
+    fi2.chmod(mode=0o755)
+    di = t.joinpath("dir")
+    di.mkdir()
+    di.chmod(mode=0o775)
 
     o = Sandcastle(
         image_reference=SANDBOX_IMAGE, k8s_namespace_name=NAMESPACE, mapped_dir=m_dir
@@ -287,7 +302,18 @@ def test_changing_mode(tmpdir):
         assert "777" == out
         stat_oct = oct(fi.stat().st_mode)[-3:]
         assert stat_oct == "777"
+
+        out = o.exec(command=["stat", "-c", "%a", "./file2"]).strip()
+        assert "755" == out
+        stat_oct = oct(fi2.stat().st_mode)[-3:]
+        assert stat_oct == "755"
+
+        out = o.exec(command=["stat", "-c", "%a", "./dir"]).strip()
+        assert "775" == out
+        stat_oct = oct(di.stat().st_mode)[-3:]
+        assert stat_oct == "775"
     finally:
+        purge_dir_content(t)
         o.delete_pod()
 
 
@@ -302,10 +328,10 @@ def test_changing_mode(tmpdir):
         ("test_exec_succ_pod", None),
         ("test_md_multiple_exec", None),
         ("test_file_got_changed", None),
-        ("test_md_e2e", None),
+        ("test_md_e2e", {"with_pv_at": SANDCASTLE_MOUNTPOINT}),
         ("test_lost_found_is_ignored", None),
         ("test_md_new_namespace", {"new_namespace": True}),
-        ("test_changing_mode", None),
+        ("test_changing_mode", {"with_pv_at": SANDCASTLE_MOUNTPOINT}),
     ),
 )
 def test_from_pod(build_now, test_name, kwargs):

--- a/tests/e2e/test_ironman.py
+++ b/tests/e2e/test_ironman.py
@@ -269,7 +269,7 @@ def test_lost_found_is_ignored(tmpdir):
     try:
         o.exec(command=["ls", "-lha", "./"])
         with pytest.raises(SandcastleCommandFailed) as ex:
-            o.exec(command=["ls", f"./lost+found"])
+            o.exec(command=["ls", "./lost+found"])
         assert "No such file or directory" in str(ex.value)
     finally:
         o.delete_pod()

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,2 @@
-kubernetes==8.0.0
 flexmock
 pytest


### PR DESCRIPTION
otherwise we are getting:

    tar: .: Cannot utime: Operation not permitted
    tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted
    tar: Exiting with failure status due to previous errors

this commit also has an updated test case how we use sandcastle in p-s

\+

* do not overwrite the custom py-kube fork
* less debug output during testing
* set exec timeout to 60 seconds