### PR TITLE
request 512M memory by default

### DIFF
--- a/sandcastle/api.py
+++ b/sandcastle/api.py
@@ -171,6 +171,10 @@ class Sandcastle(object):
             "name": self.pod_name,
             "env": env_image_vars,
             "imagePullPolicy": "IfNotPresent",
+            "resources": {
+                "limits": {"memory": "512Mi"},
+                "requests": {"memory": "512Mi"},
+            },
         }
         spec = {
             "containers": [container],

--- a/tests/unit/test_pod_and_env.py
+++ b/tests/unit/test_pod_and_env.py
@@ -212,6 +212,10 @@ def test_manifest(init_openshift_deployer):
                     "name": od.pod_name,
                     "env": [{"name": KEY, "value": VALUE}],
                     "imagePullPolicy": "IfNotPresent",
+                    "resources": {
+                        "limits": {"memory": "512Mi"},
+                        "requests": {"memory": "512Mi"},
+                    },
                 }
             ],
             "restartPolicy": "Never",


### PR DESCRIPTION
this should resolve our p-s errors:
```
(403)
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'Cache-Control': 'no-store', 'Content-Type': 'application/json', 'Date': 'Wed, 20 Nov 2019 16:24:02 GMT', 'Content-Length': '425'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \"docker-io-usercont-sandcastle-20191120-162402686738\" is forbidden: exceeded quota: 74746f6d6563656b407265646861742e636f6d-timebound, requested: limits.memory=512Mi, used: limits.memory=2Gi, limited: limits.memory=2Gi","reason":"Forbidden","details":{"name":"docker-io-usercont-sandcastle-20191120-162402686738","kind":"pods"},"code":403}
```

if not, Linus help us