### PR TITLE
Don't COPY tests/requirements.txt into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-# This is the default sandbox container image.
+# This is the default sandbox container image to run untrusted commands.
 # It should contain basic utilities, such as git, make, rpmbuild, etc.
-# Untrusted commands are meant to run in this container.
 FROM registry.fedoraproject.org/fedora:30
 
 # ANSIBLE_STDOUT_CALLBACK - nicer output from the playbook run
@@ -12,14 +11,9 @@ ENV LANG=en_US.UTF-8 \
 
 WORKDIR ${WORKDIR}
 
-RUN dnf install -y ansible && dnf clean all
+RUN dnf install -y ansible
 
 COPY files/install-rpm-packages.yaml /src/files/install-rpm-packages.yaml
-COPY tests/requirements.txt /src/tests/requirements.txt
-
-# assert
-RUN ls tests/requirements.txt
-
 RUN ansible-playbook -vv -c local -t basic-image -i localhost, files/install-rpm-packages.yaml \
     && dnf clean all
 

--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -67,7 +67,7 @@
 #         state: absent
 #     tags:
 #     - with-sandcastle-deps
-  - name:
+  - name: Install tests requirements
     pip:
       executable: /usr/bin/pip3
       requirements: "{{ lookup('env','PWD') }}/tests/requirements.txt"


### PR DESCRIPTION
I just don't understand why it's copied into the image when the [tests image includes that too](https://github.com/packit-service/sandcastle/blob/master/Dockerfile.tests#L5).